### PR TITLE
Fixed ports definition for Hass.io

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Vlad's repository",
-  "url": "https://github.com/vkorn/hassio-addons",
+  "name": "Test repository",
+  "url": "https://github.com/jamescw/hassio-addons",
   "maintainer": "vkorn <vladkorniev@gmail.com>"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Test repository",
-  "url": "https://github.com/jamescw/hassio-addons",
+  "name": "Vlad's repository",
+  "url": "https://github.com/vkorn/hassio-addons",
   "maintainer": "vkorn <vladkorniev@gmail.com>"
 }

--- a/smartthings/config.json
+++ b/smartthings/config.json
@@ -8,6 +8,9 @@
     "startup": "before",
     "boot": "auto",
     "host_network": true,
+    "ports": {
+        "8080/tcp": 8080
+    }
     "options": {
         "broker_host": "172.17.0.1",
         "broker_port": 8888,
@@ -16,7 +19,7 @@
         "command_suffix": "cmd",
         "login": "login",
         "password": "password",
-        "bridge_port": 2080
+        "bridge_port": 8080
 
     },
     "schema": {

--- a/smartthings/config.json
+++ b/smartthings/config.json
@@ -10,7 +10,7 @@
     "host_network": true,
     "ports": {
         "8080/tcp": 8080
-    }
+    },
     "options": {
         "broker_host": "172.17.0.1",
         "broker_port": 8888,

--- a/smartthings/config.json
+++ b/smartthings/config.json
@@ -7,7 +7,6 @@
     "image": "vkorn/{arch}-smartthings",
     "startup": "before",
     "boot": "auto",
-    "host_network": true,
     "ports": {
         "8080/tcp": 8080
     },

--- a/smartthings/config.json
+++ b/smartthings/config.json
@@ -12,7 +12,7 @@
     },
     "options": {
         "broker_host": "172.17.0.1",
-        "broker_port": 8888,
+        "broker_port": 1883,
         "preface": "smartthings",
         "state_suffix": "state",
         "command_suffix": "cmd",


### PR DESCRIPTION
The original `config.json` for Hass.io was missing the `ports` collection which allows the container to bind to the host and be reachable from the network for the SmartThings hub to be able communicate.
This adds the ports definition and sets some sensible defaults for the MQTT broker port and the smartthings-bridge server port.