### PR TITLE
Add 'aarch' to the add-on config

### DIFF
--- a/smartthings/config.json
+++ b/smartthings/config.json
@@ -4,6 +4,7 @@
     "slug": "smartthings",
     "description": "Smart Things Mqtt Bridge (https://github.com/stjohnjohnson/smartthings-mqtt-bridge)",
     "url": "https://github.com/vkorn/hassio-addons/tree/master/smartthings",
+    "arch": ["armhf", "aarch64", "amd64", "i386"],
     "image": "vkorn/{arch}-smartthings",
     "startup": "before",
     "boot": "auto",


### PR DESCRIPTION
'The 'aarch' tag is required for add-ons in recent versions of Hass.io, it identifies the platforms an add-on can compatibly run on.  The Hass.io team makes breaking changes like this from time to time.  I've updated the tag here to be in agreement with the vkorn/*-smartthings repositories I could find on dockerhub [here](https://hub.docker.com/u/vkorn)

I noticed this after my Hass.io instance was unable to reinstall this add-on after a restore, Hass.io complains that the tag is missing when loading your repository.  I am a fellow [add-on developer](https://github.com/sabeechen/hassio-google-drive-backup) who uses your repo.  I've tested this as a local add-on by installing it on my rpi, the installation went thorugh and I was able to run it successfully.