### PR TITLE
add arch to config.json

### DIFF
--- a/appdaemon/config.json
+++ b/appdaemon/config.json
@@ -4,6 +4,7 @@
     "slug": "appdaemon",
     "description": "Beta version of HADaemon (https://github.com/home-assistant/appdaemon/tree/hadashboard_beta)",
     "url": "https://github.com/vkorn/hassio-addons",
+    "arch": ["armhf", "aarch64", "amd64", "i386"],
     "startup": "after",
     "image": "vkorn/{arch}-appdaemon",
     "boot": "auto",

--- a/configwatcher/config.json
+++ b/configwatcher/config.json
@@ -4,6 +4,7 @@
     "slug": "configwatcher",
     "description": "Config watchdog which will perform restarts if required",
     "url": "https://github.com/vkorn/hassio-addons/tree/master/configwatcher",
+    "arch": ["armhf", "aarch64", "amd64", "i386"],
     "image": "vkorn/{arch}-configwatcher",
     "startup": "after",
     "boot": "auto",

--- a/devicelocator/config.json
+++ b/devicelocator/config.json
@@ -4,6 +4,7 @@
     "slug": "devlocator",
     "description": "Simple IP and device name loockup for internal network",
     "url": "https://github.com/vkorn/hassio-addons/tree/master/devicelocator",
+    "arch": ["armhf", "aarch64", "amd64", "i386"],
     "image": "vkorn/{arch}-devicelocator",
     "startup": "after",
     "boot": "auto",

--- a/ps4waker/config.json
+++ b/ps4waker/config.json
@@ -4,6 +4,7 @@
     "slug": "ps4waker",
     "description": "REST wrapper around PS4-Waker (https://github.com/dhleong/ps4-waker)",
     "url": "https://github.com/vkorn/hassio-addons/tree/master/ps4waker",
+    "arch": ["armhf", "aarch64", "amd64", "i386"],
     "image": "vkorn/{arch}-ps4waker",
     "startup": "after",
     "boot": "auto",


### PR DESCRIPTION
breaking change in hass.io, requires arch in order to add repositories in addon-store.